### PR TITLE
Fix double-conf issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -85,7 +85,7 @@ if [ "$AUTH_METHOD" = "mysql" ]; then
 
 # PostgreSQL auth
 elif [ "$AUTH_METHOD" = "pgsql" ]; then
-  FLAGS="$FLAGS --login pgsql:${PFTPD_PGSQL_CONF}"p
+  FLAGS="$FLAGS --login pgsql:${PFTPD_PGSQL_CONF}"
   if [ ! -f "${PFTPD_PGSQL_CONF}" ]; then
     >&2 echo "ERROR: ${PFTPD_PGSQL_CONF} does not exist"
     exit 1


### PR DESCRIPTION
This was probably a typo.
It caused the program to not start if you do not provide both:

`/data/pureftpd-pgsql.conf`
`/data/pureftpd-pgsql.confp`

Regards